### PR TITLE
[feat] SQS를 이용한 메세지 수신 및 선물하기 상태 변경 기능 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,10 @@ dependencies {
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
     implementation 'com.squareup.okhttp3:logging-interceptor'
+    
+    // aws sqs
+    implementation platform('software.amazon.awssdk:bom:2.15.0')
+    implementation 'org.springframework.cloud:spring-cloud-aws-messaging:2.2.1.RELEASE'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/dev/practice/gift/application/GiftFacade.java
+++ b/src/main/java/dev/practice/gift/application/GiftFacade.java
@@ -24,4 +24,12 @@ public class GiftFacade {
 		log.info("registerOrder orderToken = {}", giftInfo);
 		return giftInfo;
 	}
+
+	public void requestPaymentProcessing(String giftToken) {
+		giftService.requestPaymentProcessing(giftToken);
+	}
+
+	public void completePayment(String orderToken) {
+		giftService.completePayment(orderToken);
+	}
 }

--- a/src/main/java/dev/practice/gift/common/exception/EntityNotFoundException.java
+++ b/src/main/java/dev/practice/gift/common/exception/EntityNotFoundException.java
@@ -1,0 +1,10 @@
+package dev.practice.gift.common.exception;
+
+import dev.practice.gift.common.response.ErrorCode;
+
+public class EntityNotFoundException extends BaseException {
+
+	public EntityNotFoundException() {
+		super(ErrorCode.COMMON_INVALID_PARAMETER);
+	}
+}

--- a/src/main/java/dev/practice/gift/common/exception/IllegalStatusException.java
+++ b/src/main/java/dev/practice/gift/common/exception/IllegalStatusException.java
@@ -1,0 +1,10 @@
+package dev.practice.gift.common.exception;
+
+import dev.practice.gift.common.response.ErrorCode;
+
+public class IllegalStatusException extends BaseException {
+
+	public IllegalStatusException(String message) {
+		super(message, ErrorCode.COMMON_ILLEGAL_STATUS);
+	}
+}

--- a/src/main/java/dev/practice/gift/common/interceptor/CommonHttpRequestInterceptor.java
+++ b/src/main/java/dev/practice/gift/common/interceptor/CommonHttpRequestInterceptor.java
@@ -1,0 +1,28 @@
+package dev.practice.gift.common.interceptor;
+
+import java.util.UUID;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.AsyncHandlerInterceptor;
+
+@Component
+public class CommonHttpRequestInterceptor implements AsyncHandlerInterceptor {
+
+	public static final String HEADER_REQUEST_UUID_KEY = "x-request-id";
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+		String requestEventId = request.getHeader(HEADER_REQUEST_UUID_KEY);
+		if (StringUtils.isEmpty(requestEventId)) {
+			requestEventId = UUID.randomUUID().toString();
+		}
+		MDC.put(HEADER_REQUEST_UUID_KEY, requestEventId);
+		return true;
+	}
+}
+

--- a/src/main/java/dev/practice/gift/common/response/CommonControllerAdvice.java
+++ b/src/main/java/dev/practice/gift/common/response/CommonControllerAdvice.java
@@ -1,0 +1,81 @@
+package dev.practice.gift.common.response;
+
+import java.util.List;
+
+import org.slf4j.MDC;
+import org.springframework.core.NestedExceptionUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import com.google.common.collect.Lists;
+
+import dev.practice.gift.common.exception.BaseException;
+import dev.practice.gift.common.interceptor.CommonHttpRequestInterceptor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ControllerAdvice
+public class CommonControllerAdvice {
+
+	private static final List<ErrorCode> SPECIFIC_ALERT_TARGET_ERROR_CODE_LIST = Lists.newArrayList();
+
+	/**
+	 * http status: 500 AND result: FAIL
+	 * 시스템 예외 상황. 집중 모니터링 대상
+	 */
+	@ResponseBody
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	@ExceptionHandler(value = Exception.class)
+	public CommonResponse onException(Exception e) {
+		String eventId = MDC.get(CommonHttpRequestInterceptor.HEADER_REQUEST_UUID_KEY);
+		log.error("eventId = {}", eventId, e);
+		return CommonResponse.fail(ErrorCode.COMMON_SYSTEM_ERROR);
+	}
+
+	/**
+	 * http status: 200 AND result: FAIL
+	 * 시스템은 이슈 없고, 비즈니스 로직 처리에서 에러가 발생함
+	 */
+	@ResponseBody
+	@ResponseStatus(HttpStatus.OK)
+	@ExceptionHandler(value = BaseException.class)
+	public CommonResponse onBaseException(BaseException e) {
+		String eventId = MDC.get(CommonHttpRequestInterceptor.HEADER_REQUEST_UUID_KEY);
+		if (SPECIFIC_ALERT_TARGET_ERROR_CODE_LIST.contains(e.getErrorCode())) {
+			log.error("[BaseException] eventId = {}, cause = {}", eventId, NestedExceptionUtils.getMostSpecificCause(e),
+				NestedExceptionUtils.getMostSpecificCause(e).getMessage());
+		} else {
+			log.warn("[BaseException] eventId = {}, cause = {}", eventId, NestedExceptionUtils.getMostSpecificCause(e),
+				NestedExceptionUtils.getMostSpecificCause(e).getMessage());
+		}
+		return CommonResponse.fail(e.getMessage(), e.getErrorCode().name());
+	}
+
+	/**
+	 * http status: 400 AND result: FAIL
+	 * request parameter 에러
+	 */
+	@ResponseBody
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(value = {MethodArgumentNotValidException.class})
+	public CommonResponse methodArgumentNotValidException(MethodArgumentNotValidException e) {
+		String eventId = MDC.get(CommonHttpRequestInterceptor.HEADER_REQUEST_UUID_KEY);
+		log.warn("[BaseException] eventId = {}, errorMsg = {}", eventId,
+			NestedExceptionUtils.getMostSpecificCause(e).getMessage());
+		BindingResult bindingResult = e.getBindingResult();
+		FieldError fieldError = bindingResult.getFieldError();
+		if (fieldError != null) {
+			String message = "Request Error" + " " + fieldError.getField() + "=" + fieldError.getRejectedValue() + " ("
+				+ fieldError.getDefaultMessage() + ")";
+			return CommonResponse.fail(message, ErrorCode.COMMON_INVALID_PARAMETER.name());
+		} else {
+			return CommonResponse.fail("요청한 값이 올바르지 않습니다.", ErrorCode.COMMON_INVALID_PARAMETER.name());
+		}
+	}
+}

--- a/src/main/java/dev/practice/gift/common/response/CommonResponse.java
+++ b/src/main/java/dev/practice/gift/common/response/CommonResponse.java
@@ -27,6 +27,22 @@ public class CommonResponse<T> {
 			.build();
 	}
 
+	public static CommonResponse fail(String message, String errorCode) {
+		return CommonResponse.builder()
+			.result(Result.FAIL)
+			.message(message)
+			.errorCode(errorCode)
+			.build();
+	}
+
+	public static CommonResponse fail(ErrorCode errorCode) {
+		return CommonResponse.builder()
+			.result(Result.FAIL)
+			.message(errorCode.getErrorMsg())
+			.errorCode(errorCode.name())
+			.build();
+	}
+
 	public enum Result {
 		SUCCESS, FAIL
 	}

--- a/src/main/java/dev/practice/gift/common/response/ErrorCode.java
+++ b/src/main/java/dev/practice/gift/common/response/ErrorCode.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
+	COMMON_SYSTEM_ERROR("일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요."), // 장애 상황
+	COMMON_ENTITY_NOT_FOUND("존재하지 않는 엔티티입니다."),
 	COMMON_INVALID_PARAMETER("요청한 값이 올바르지 않습니다."),
 	COMMON_ILLEGAL_STATUS("잘못된 상태값 잆니다.");
 

--- a/src/main/java/dev/practice/gift/config/AwsSqsConfig.java
+++ b/src/main/java/dev/practice/gift/config/AwsSqsConfig.java
@@ -1,0 +1,33 @@
+package dev.practice.gift.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
+
+@Configuration
+public class AwsSqsConfig {
+	@Value("${cloud.aws.secretKey}")
+	private String awsAccessKey;
+
+	@Value("${cloud.aws.secretKey}")
+	private String awsSecretKey;
+
+	@Bean
+	public AmazonSQSAsync amazonSQSAsync() {
+		AWSCredentialsProvider awsCredentialsProvider = new AWSStaticCredentialsProvider(
+			new BasicAWSCredentials(awsAccessKey, awsSecretKey));
+
+		return AmazonSQSAsyncClientBuilder
+			.standard()
+			.withRegion(Regions.AP_NORTHEAST_2)
+			.withCredentials(awsCredentialsProvider)
+			.build();
+	}
+}

--- a/src/main/java/dev/practice/gift/config/JpaAuditingConfiguration.java
+++ b/src/main/java/dev/practice/gift/config/JpaAuditingConfiguration.java
@@ -1,0 +1,9 @@
+package dev.practice.gift.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+}

--- a/src/main/java/dev/practice/gift/domain/gift/Gift.java
+++ b/src/main/java/dev/practice/gift/domain/gift/Gift.java
@@ -10,8 +10,9 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
-import org.springframework.util.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
+import dev.practice.gift.common.exception.IllegalStatusException;
 import dev.practice.gift.common.exception.InvalidParamException;
 import dev.practice.gift.common.util.TokenGenerator;
 import dev.practice.gift.domain.AbstractEntity;
@@ -111,5 +112,18 @@ public class Gift extends AbstractEntity {
 		this.giftReceiverPhone = giftReceiverPhone;
 		this.giftMessage = giftMessage;
 		this.expiredAt = ZonedDateTime.now().plusDays(7);
+	}
+
+	public void inPayment() {
+		if (this.status != Status.INIT)
+			throw new IllegalStatusException("Gift inPayment");
+		this.status = Status.IN_PAYMENT;
+	}
+
+	public void completePayment() {
+		if (this.status != Status.IN_PAYMENT)
+			throw new IllegalStatusException("Gift paymentComplete");
+		this.status = Status.ORDER_COMPLETE;
+		this.paidAt = ZonedDateTime.now();
 	}
 }

--- a/src/main/java/dev/practice/gift/domain/gift/GiftReader.java
+++ b/src/main/java/dev/practice/gift/domain/gift/GiftReader.java
@@ -2,4 +2,6 @@ package dev.practice.gift.domain.gift;
 
 public interface GiftReader {
 	Gift getGiftBy(String giftToken);
+
+	Gift getGiftByOrderToken(String orderToken);
 }

--- a/src/main/java/dev/practice/gift/domain/gift/GiftService.java
+++ b/src/main/java/dev/practice/gift/domain/gift/GiftService.java
@@ -4,4 +4,8 @@ public interface GiftService {
 	GiftInfo getGiftInfo(String giftToken);
 
 	GiftInfo registerOrder(GiftCommand.Register request);
+
+	void requestPaymentProcessing(String giftToken);
+
+	void completePayment(String orderToken);
 }

--- a/src/main/java/dev/practice/gift/domain/gift/GiftServiceImpl.java
+++ b/src/main/java/dev/practice/gift/domain/gift/GiftServiceImpl.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class GiftServiceImpl implements GiftService {
 	private final GiftReader giftReader;
 	private final GiftStore giftStore;
@@ -22,11 +21,26 @@ public class GiftServiceImpl implements GiftService {
 	}
 
 	@Override
+	@Transactional
 	public GiftInfo registerOrder(GiftCommand.Register request) {
 		var orderCommand = giftToOrderMapper.of(request);
 		var orderToken = orderApiCaller.registerGiftOrder(orderCommand);
 		var initGift = request.toEntity(orderToken);
 		var gift = giftStore.store(initGift);
 		return new GiftInfo(gift);
+	}
+
+	@Override
+	@Transactional
+	public void requestPaymentProcessing(String giftToken) {
+		var gift = giftReader.getGiftBy(giftToken);
+		gift.inPayment();
+	}
+
+	@Override
+	@Transactional
+	public void completePayment(String orderToken) {
+		var gift = giftReader.getGiftByOrderToken(orderToken);
+		gift.completePayment();
 	}
 }

--- a/src/main/java/dev/practice/gift/infrastructure/aws/AwsSqsListenerConfig.java
+++ b/src/main/java/dev/practice/gift/infrastructure/aws/AwsSqsListenerConfig.java
@@ -1,0 +1,67 @@
+package dev.practice.gift.infrastructure.aws;
+
+import java.util.Collections;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.aws.messaging.config.QueueMessageHandlerFactory;
+import org.springframework.cloud.aws.messaging.config.SimpleMessageListenerContainerFactory;
+import org.springframework.cloud.aws.messaging.listener.QueueMessageHandler;
+import org.springframework.cloud.aws.messaging.listener.SimpleMessageListenerContainer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.handler.annotation.support.PayloadMethodArgumentResolver;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Component;
+
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+
+@Component
+public class AwsSqsListenerConfig {
+
+	@Bean
+	public SimpleMessageListenerContainerFactory simpleMessageListenerContainerFactory(AmazonSQSAsync amazonSQSAsync) {
+		SimpleMessageListenerContainerFactory factory = new SimpleMessageListenerContainerFactory();
+		factory.setAmazonSqs(amazonSQSAsync);
+		factory.setAutoStartup(true);
+		return factory;
+	}
+
+	@Bean
+	public SimpleMessageListenerContainer simpleMessageListenerContainer(
+		SimpleMessageListenerContainerFactory simpleMessageListenerContainerFactory,
+		QueueMessageHandler queueMessageHandler,
+		ThreadPoolTaskExecutor messageThreadPoolTaskExecutor) {
+		SimpleMessageListenerContainer container = simpleMessageListenerContainerFactory.createSimpleMessageListenerContainer();
+		container.setMessageHandler(queueMessageHandler);
+		container.setTaskExecutor(messageThreadPoolTaskExecutor);
+		return container;
+	}
+
+	@Bean
+	@ConditionalOnMissingBean(QueueMessageHandler.class)
+	public QueueMessageHandlerFactory queueMessageHandlerFactory(AmazonSQSAsync amazonSQSAsync) {
+		QueueMessageHandlerFactory factory = new QueueMessageHandlerFactory();
+		factory.setAmazonSqs(amazonSQSAsync);
+
+		MappingJackson2MessageConverter messageConverter = new MappingJackson2MessageConverter();
+		messageConverter.setStrictContentTypeMatch(false);
+		factory.setArgumentResolvers(Collections.singletonList(new PayloadMethodArgumentResolver(messageConverter)));
+		return factory;
+	}
+
+	@Bean
+	@ConditionalOnMissingBean(QueueMessageHandler.class)
+	public QueueMessageHandler queueMessageHandler(QueueMessageHandlerFactory queueMessageHandlerFactory) {
+		return queueMessageHandlerFactory.createQueueMessageHandler();
+	}
+
+	@Bean
+	public ThreadPoolTaskExecutor messageThreadPoolTaskExecutor() {
+		ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+		taskExecutor.setThreadNamePrefix("sqs-");
+		taskExecutor.setCorePoolSize(8);
+		taskExecutor.setMaxPoolSize(100);
+		taskExecutor.afterPropertiesSet();
+		return taskExecutor;
+	}
+}

--- a/src/main/java/dev/practice/gift/infrastructure/gift/GiftReaderImpl.java
+++ b/src/main/java/dev/practice/gift/infrastructure/gift/GiftReaderImpl.java
@@ -1,10 +1,9 @@
 package dev.practice.gift.infrastructure.gift;
 
-import javax.persistence.EntityNotFoundException;
-
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
+import dev.practice.gift.common.exception.EntityNotFoundException;
 import dev.practice.gift.common.exception.InvalidParamException;
 import dev.practice.gift.domain.gift.Gift;
 import dev.practice.gift.domain.gift.GiftReader;
@@ -20,6 +19,14 @@ public class GiftReaderImpl implements GiftReader {
 		if (StringUtils.isBlank(giftToken))
 			throw new InvalidParamException();
 		return giftRepository.findByGiftToken(giftToken)
+			.orElseThrow(EntityNotFoundException::new);
+	}
+
+	@Override
+	public Gift getGiftByOrderToken(String orderToken) {
+		if (StringUtils.isEmpty(orderToken))
+			throw new InvalidParamException();
+		return giftRepository.findByOrderToken(orderToken)
 			.orElseThrow(EntityNotFoundException::new);
 	}
 }

--- a/src/main/java/dev/practice/gift/infrastructure/gift/GiftRepository.java
+++ b/src/main/java/dev/practice/gift/infrastructure/gift/GiftRepository.java
@@ -8,4 +8,6 @@ import dev.practice.gift.domain.gift.Gift;
 
 public interface GiftRepository extends JpaRepository<Gift, Long> {
 	Optional<Gift> findByGiftToken(String giftToken);
+
+	Optional<Gift> findByOrderToken(String orderToken);
 }

--- a/src/main/java/dev/practice/gift/interfaces/api/GiftApiController.java
+++ b/src/main/java/dev/practice/gift/interfaces/api/GiftApiController.java
@@ -32,4 +32,10 @@ public class GiftApiController {
 		var giftInfo = giftFacade.registerOrder(command);
 		return CommonResponse.success(new GiftDto.RegisterResponse(giftInfo));
 	}
+
+	@PostMapping("/{giftToken}/payment-processing")
+	public CommonResponse requestPaymentProcessing(@PathVariable String giftToken) {
+		giftFacade.requestPaymentProcessing(giftToken);
+		return CommonResponse.success("OK");
+	}
 }

--- a/src/main/java/dev/practice/gift/interfaces/api/GiftDto.java
+++ b/src/main/java/dev/practice/gift/interfaces/api/GiftDto.java
@@ -94,4 +94,11 @@ public class GiftDto {
 			this.giftToken = giftInfo.getGiftToken();
 		}
 	}
+
+	@Getter
+	@Setter
+	@ToString
+	public static class CompletePaymentRequest {
+		private String orderToken;
+	}
 }

--- a/src/main/java/dev/practice/gift/interfaces/message/GiftPaymentCompleteMessage.java
+++ b/src/main/java/dev/practice/gift/interfaces/message/GiftPaymentCompleteMessage.java
@@ -1,0 +1,12 @@
+package dev.practice.gift.interfaces.message;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+public class GiftPaymentCompleteMessage {
+	private String orderToken;
+}

--- a/src/main/java/dev/practice/gift/interfaces/message/GiftSqsMessageListener.java
+++ b/src/main/java/dev/practice/gift/interfaces/message/GiftSqsMessageListener.java
@@ -1,0 +1,23 @@
+package dev.practice.gift.interfaces.message;
+
+import org.springframework.cloud.aws.messaging.listener.SqsMessageDeletionPolicy;
+import org.springframework.cloud.aws.messaging.listener.annotation.SqsListener;
+import org.springframework.stereotype.Component;
+
+import dev.practice.gift.application.GiftFacade;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GiftSqsMessageListener {
+	private final GiftFacade giftFacade;
+
+	@SqsListener(value = "order-payComplete-live.info", deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
+	public void readMessage(GiftPaymentCompleteMessage message) {
+		var orderToken = message.getOrderToken();
+		log.info("[GiftSqsMessageListener.readMessage] orderToken = {}", orderToken);
+		giftFacade.completePayment(orderToken);
+	}
+}


### PR DESCRIPTION
## Issues
- #7 

## What is this PR? 👓
SQS를 이용한 메세지 발행 및 선물하기 상태 변경 기능 # Gift Service, Controlelr
- 주문이 성공적으로 저장되면 결제 요청을 전달하고 결제 요청이 성공적으로 완료되면 AWS SQS 기능을 이용해 결제 완료 메세지를 수신 후, 선물하기 Gift의 상태를 변경하였습니다.
  - [x] **결제중** : **`IN_PAYMENT`** -> 중복 결제를 방지 하기 위한 Status
  - [x] **주문 완료** : **`ORDER_COMPLETE`** -> 결제가 완료된 Status

<img width="720" alt="스크린샷 2024-07-03 오후 4 33 22" src="https://github.com/pie2457/gift/assets/104147789/12397c0a-d17d-405d-858a-cc0ec1f643ce">

