### PR TITLE
[feat] 선물 수락 시 배송 정보 업데이트 기능

### DIFF
--- a/src/main/java/dev/practice/gift/application/GiftFacade.java
+++ b/src/main/java/dev/practice/gift/application/GiftFacade.java
@@ -32,4 +32,8 @@ public class GiftFacade {
 	public void completePayment(String orderToken) {
 		giftService.completePayment(orderToken);
 	}
+
+	public void acceptGift(GiftCommand.Accept request) {
+		giftService.acceptGift(request);
+	}
 }

--- a/src/main/java/dev/practice/gift/common/exception/IllegalStatusException.java
+++ b/src/main/java/dev/practice/gift/common/exception/IllegalStatusException.java
@@ -4,6 +4,10 @@ import dev.practice.gift.common.response.ErrorCode;
 
 public class IllegalStatusException extends BaseException {
 
+	public IllegalStatusException() {
+		super(ErrorCode.COMMON_ILLEGAL_STATUS);
+	}
+
 	public IllegalStatusException(String message) {
 		super(message, ErrorCode.COMMON_ILLEGAL_STATUS);
 	}

--- a/src/main/java/dev/practice/gift/config/AwsSqsConfig.java
+++ b/src/main/java/dev/practice/gift/config/AwsSqsConfig.java
@@ -13,10 +13,10 @@ import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
 
 @Configuration
 public class AwsSqsConfig {
-	@Value("${cloud.aws.secretKey}")
+	@Value("${cloud.aws.access-key}")
 	private String awsAccessKey;
 
-	@Value("${cloud.aws.secretKey}")
+	@Value("${cloud.aws.secret-key}")
 	private String awsSecretKey;
 
 	@Bean

--- a/src/main/java/dev/practice/gift/domain/gift/Gift.java
+++ b/src/main/java/dev/practice/gift/domain/gift/Gift.java
@@ -126,4 +126,41 @@ public class Gift extends AbstractEntity {
 		this.status = Status.ORDER_COMPLETE;
 		this.paidAt = ZonedDateTime.now();
 	}
+
+	public void accept(GiftCommand.Accept request) {
+		var receiverName = request.getReceiverName();
+		var receiverPhone = request.getReceiverPhone();
+		var receiverZipcode = request.getReceiverZipcode();
+		var receiverAddress = request.getReceiverAddress();
+		var receiverDetailAddress = request.getReceiverDetailAddress();
+		var etcMessage = request.getEtcMessage();
+
+		if (!availableAccept())
+			throw new IllegalStatusException();
+		if (StringUtils.isEmpty(receiverName))
+			throw new InvalidParamException("Gift accept receiverName is empty");
+		if (StringUtils.isEmpty(receiverPhone))
+			throw new InvalidParamException("Gift accept receiverPhone is empty");
+		if (StringUtils.isEmpty(receiverZipcode))
+			throw new InvalidParamException("Gift accept receiverZipcode is empty");
+		if (StringUtils.isEmpty(receiverAddress))
+			throw new InvalidParamException("Gift accept receiverAddress is empty");
+		if (StringUtils.isEmpty(receiverDetailAddress))
+			throw new InvalidParamException("Gift accept receiverDetailAddress is empty");
+
+		this.status = Status.ACCEPT;
+		this.receiverName = receiverName;
+		this.receiverPhone = receiverPhone;
+		this.receiverZipcode = receiverZipcode;
+		this.receiverAddress = receiverAddress;
+		this.receiverDetailAddress = receiverDetailAddress;
+		this.etcMessage = etcMessage;
+		this.acceptedAt = ZonedDateTime.now();
+	}
+
+	private boolean availableAccept() {
+		if (this.expiredAt.isBefore(ZonedDateTime.now()))
+			return false;
+		return this.status == Status.ORDER_COMPLETE || this.status == Status.PUSH_COMPLETE;
+	}
 }

--- a/src/main/java/dev/practice/gift/domain/gift/GiftService.java
+++ b/src/main/java/dev/practice/gift/domain/gift/GiftService.java
@@ -8,4 +8,6 @@ public interface GiftService {
 	void requestPaymentProcessing(String giftToken);
 
 	void completePayment(String orderToken);
+
+	void acceptGift(GiftCommand.Accept request);
 }

--- a/src/main/java/dev/practice/gift/domain/gift/GiftServiceImpl.java
+++ b/src/main/java/dev/practice/gift/domain/gift/GiftServiceImpl.java
@@ -43,4 +43,13 @@ public class GiftServiceImpl implements GiftService {
 		var gift = giftReader.getGiftByOrderToken(orderToken);
 		gift.completePayment();
 	}
+
+	@Override
+	@Transactional
+	public void acceptGift(GiftCommand.Accept request) {
+		var gift = giftReader.getGiftBy(request.getGiftToken());
+		gift.accept(request);
+
+		orderApiCaller.updateReceiverInfo(gift.getOrderToken(), request);
+	}
 }

--- a/src/main/java/dev/practice/gift/domain/gift/order/OrderApiCaller.java
+++ b/src/main/java/dev/practice/gift/domain/gift/order/OrderApiCaller.java
@@ -1,5 +1,9 @@
 package dev.practice.gift.domain.gift.order;
 
+import dev.practice.gift.domain.gift.GiftCommand;
+
 public interface OrderApiCaller {
 	String registerGiftOrder(OrderApiCommand.Register request);
+
+	void updateReceiverInfo(String orderToken, GiftCommand.Accept request);
 }

--- a/src/main/java/dev/practice/gift/infrastructure/gift/order/OrderApiCallerImpl.java
+++ b/src/main/java/dev/practice/gift/infrastructure/gift/order/OrderApiCallerImpl.java
@@ -3,6 +3,7 @@ package dev.practice.gift.infrastructure.gift.order;
 import org.springframework.stereotype.Component;
 
 import dev.practice.gift.common.response.CommonResponse;
+import dev.practice.gift.domain.gift.GiftCommand;
 import dev.practice.gift.domain.gift.order.OrderApiCaller;
 import dev.practice.gift.domain.gift.order.OrderApiCommand;
 import dev.practice.gift.infrastructure.retrofit.RetrofitUtils;
@@ -21,5 +22,11 @@ public class OrderApiCallerImpl implements OrderApiCaller {
 			.map(CommonResponse::getData)
 			.map(RetrofitOrderApiResponse.Register::getOrderToken)
 			.orElseThrow(RuntimeException::new);
+	}
+
+	@Override
+	public void updateReceiverInfo(String orderToken, GiftCommand.Accept request) {
+		var call = retrofitOrderApi.updateReceiverInfo(orderToken, request);
+		retrofitUtils.responseVoid(call);
 	}
 }

--- a/src/main/java/dev/practice/gift/infrastructure/gift/order/RetrofitOrderApi.java
+++ b/src/main/java/dev/practice/gift/infrastructure/gift/order/RetrofitOrderApi.java
@@ -1,13 +1,18 @@
 package dev.practice.gift.infrastructure.gift.order;
 
 import dev.practice.gift.common.response.CommonResponse;
+import dev.practice.gift.domain.gift.GiftCommand;
 import dev.practice.gift.domain.gift.order.OrderApiCommand;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.POST;
+import retrofit2.http.Path;
 
 public interface RetrofitOrderApi {
 
 	@POST("api/v1/orders/init")
 	Call<CommonResponse<RetrofitOrderApiResponse.Register>> registerOrder(@Body OrderApiCommand.Register request);
+
+	@POST("api/v1/gift-orders/{orderToken}/update-receiver-info")
+	Call<Void> updateReceiverInfo(@Path("orderToken") String orderToken, @Body GiftCommand.Accept request);
 }

--- a/src/main/java/dev/practice/gift/infrastructure/retrofit/RetrofitUtils.java
+++ b/src/main/java/dev/practice/gift/infrastructure/retrofit/RetrofitUtils.java
@@ -55,4 +55,13 @@ public class RetrofitUtils {
 			throw new RuntimeException("retrofit execute IOException");
 		}
 	}
+
+	public void responseVoid(Call<Void> call) {
+		try {
+			if (!call.execute().isSuccessful())
+				throw new RuntimeException();
+		} catch (IOException e) {
+			throw new RuntimeException();
+		}
+	}
 }

--- a/src/main/java/dev/practice/gift/interfaces/api/GiftApiController.java
+++ b/src/main/java/dev/practice/gift/interfaces/api/GiftApiController.java
@@ -38,4 +38,14 @@ public class GiftApiController {
 		giftFacade.requestPaymentProcessing(giftToken);
 		return CommonResponse.success("OK");
 	}
+
+	@PostMapping("/{giftToken}/accept-gift")
+	public CommonResponse acceptGift(
+		@PathVariable String giftToken,
+		@RequestBody @Valid GiftDto.AcceptGiftRequest request
+	) {
+		var acceptCommand = giftDtoMapper.of(giftToken, request);
+		giftFacade.acceptGift(acceptCommand);
+		return CommonResponse.success("OK");
+	}
 }

--- a/src/main/java/dev/practice/gift/interfaces/api/GiftDto.java
+++ b/src/main/java/dev/practice/gift/interfaces/api/GiftDto.java
@@ -101,4 +101,26 @@ public class GiftDto {
 	public static class CompletePaymentRequest {
 		private String orderToken;
 	}
+
+	@Getter
+	@Setter
+	@ToString
+	public static class AcceptGiftRequest {
+		@NotBlank(message = "receiverName 는 필수값 입니다.")
+		private String receiverName;
+
+		@NotBlank(message = "receiverPhone 는 필수값 입니다.")
+		private String receiverPhone;
+
+		@NotBlank(message = "receiverZipcode 는 필수값 입니다.")
+		private String receiverZipcode;
+
+		@NotBlank(message = "receiverAddress 는 필수값 입니다.")
+		private String receiverAddress;
+
+		@NotBlank(message = "receiverDetailAddress 는 필수값 입니다.")
+		private String receiverDetailAddress;
+
+		private String etcMessage;
+	}
 }

--- a/src/main/java/dev/practice/gift/interfaces/api/GiftDtoMapper.java
+++ b/src/main/java/dev/practice/gift/interfaces/api/GiftDtoMapper.java
@@ -19,4 +19,6 @@ public interface GiftDtoMapper {
 	GiftCommand.RegisterOrderItemOptionGroup of(GiftDto.RegisterOrderItemOptionGroupRequest request);
 
 	GiftCommand.RegisterOrderItemOption of(GiftDto.RegisterOrderItemOptionRequest request);
+
+	GiftCommand.Accept of(String giftToken, GiftDto.AcceptGiftRequest request);
 }


### PR DESCRIPTION
## Issues
- #9 

## What is this PR? 👓
선물 수락 시 배송 정보 업데이트 기능 # Gift Service, Controlelr
- 선물 수령자가 배송지를 입력하고 `선물 수락` 을 하면,
  선물 상태를 `Accept`로 변경하고 주문 서비스 API를 호출하여 주문의 배송지 주소를 업데이트 합니다.